### PR TITLE
Making orders async

### DIFF
--- a/orders-core/pom.xml
+++ b/orders-core/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>bson</artifactId>
             <version>${version.lib.mongo}</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.30</version>
+        </dependency>
+
 
         <!-- test dependencies -->
         <dependency>

--- a/orders-core/pom.xml
+++ b/orders-core/pom.xml
@@ -123,6 +123,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/ClearDefaultOrderRepository*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
+++ b/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
@@ -2,6 +2,8 @@ package io.helidon.examples.sockshop.orders;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -39,20 +41,21 @@ public class DefaultOrderRepository implements OrderRepository {
     }
 
     @Override
-    public Collection<? extends Order> findOrdersByCustomer(String customerId) {
-        return orders.values().stream()
+    public CompletionStage<Collection<? extends Order>> findOrdersByCustomer(String customerId) {
+        return CompletableFuture.completedStage(orders.values().stream()
                 .filter(order -> order.getCustomer().getId().equals(customerId))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
-    public Order get(String orderId) {
-        return orders.get(orderId);
+    public CompletionStage<Order> get(String orderId) {
+        return CompletableFuture.completedStage(orders.get(orderId));
     }
 
     @Override
-    public void saveOrder(Order order) {
+    public CompletionStage saveOrder(Order order) {
         orders.put(order.getOrderId(), order);
+        return CompletableFuture.completedStage(null);
     }
 
     // ---- helpers ---------------------------------------------------------
@@ -60,7 +63,8 @@ public class DefaultOrderRepository implements OrderRepository {
     /**
      * Helper to clear this repository for testing.
      */
-    public void clear() {
+    public CompletionStage clear() {
         orders.clear();
+        return CompletableFuture.completedStage(null);
     }
 }

--- a/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
+++ b/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
@@ -7,7 +7,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
 
 import org.eclipse.microprofile.opentracing.Traced;
 
@@ -20,9 +23,11 @@ import org.eclipse.microprofile.opentracing.Traced;
  * API testing and quick demos.
  */
 @ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+1)
 @Traced
 public class DefaultOrderRepository implements OrderRepository {
-    private Map<String, Order> orders;
+    protected Map<String, Order> orders;
 
     /**
      * Construct {@code DefaultOrderRepository} with empty storage map.
@@ -55,16 +60,6 @@ public class DefaultOrderRepository implements OrderRepository {
     @Override
     public CompletionStage saveOrder(Order order) {
         orders.put(order.getOrderId(), order);
-        return CompletableFuture.completedStage(null);
-    }
-
-    // ---- helpers ---------------------------------------------------------
-
-    /**
-     * Helper to clear this repository for testing.
-     */
-    public CompletionStage clear() {
-        orders.clear();
         return CompletableFuture.completedStage(null);
     }
 }

--- a/orders-core/src/main/java/io/helidon/examples/sockshop/orders/OrderRepository.java
+++ b/orders-core/src/main/java/io/helidon/examples/sockshop/orders/OrderRepository.java
@@ -1,6 +1,7 @@
 package io.helidon.examples.sockshop.orders;
 
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 
 /**
  * A repository interface that should be implemented by
@@ -14,7 +15,7 @@ public interface OrderRepository {
      *
      * @return all orders for the specified customer
      */
-    Collection<? extends Order> findOrdersByCustomer(String customerId);
+    CompletionStage<Collection<? extends Order>> findOrdersByCustomer(String customerId);
 
     /**
      * Get an existing order.
@@ -24,12 +25,12 @@ public interface OrderRepository {
      * @return an existing order, or {@code null} if the specified order
      *         does not exist
      */
-    Order get(String orderId);
+    CompletionStage<Order> get(String orderId);
 
     /**
      * Save order.
      *
      * @param order the order to save
      */
-    void saveOrder(Order order);
+    CompletionStage saveOrder(Order order);
 }

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/ClearDefaultOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/ClearDefaultOrderRepository.java
@@ -1,0 +1,23 @@
+package io.helidon.examples.sockshop.orders;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.enterprise.inject.Specializes;
+
+@Specializes
+public class ClearDefaultOrderRepository extends DefaultOrderRepository implements ClearOrderRepository {
+    public ClearDefaultOrderRepository() {}
+
+    @Override
+    public CompletionStage clear() {
+        clearRepository(this);
+        return CompletableFuture.completedStage(null);
+    }
+
+    public static void clearRepository(DefaultOrderRepository dor) {
+        dor.orders.clear();
+    }
+}

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/ClearOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/ClearOrderRepository.java
@@ -1,0 +1,9 @@
+package io.helidon.examples.sockshop.orders;
+
+import java.util.concurrent.CompletionStage;
+
+// Tests need to interact with the entity backing OrderRepository
+// to reset to initial state before every test
+public interface ClearOrderRepository {
+    public CompletionStage clear();
+}

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
@@ -11,6 +11,6 @@ public class DefaultOrderRepositoryTest extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((DefaultOrderRepository) orders).clear().toCompletableFuture().join();
+        ClearDefaultOrderRepository.clearRepository((DefaultOrderRepository) orders);
     }
 }

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
@@ -11,6 +11,6 @@ public class DefaultOrderRepositoryTest extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((DefaultOrderRepository) orders).clear();
+        ((DefaultOrderRepository) orders).clear().toCompletableFuture().join();
     }
 }

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderRepositoryTest.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderRepositoryTest.java
@@ -24,20 +24,20 @@ public abstract class OrderRepositoryTest {
 
     @Test
     void testFindOrdersByCustomer() {
-        orders.saveOrder(order("homer", 1));
-        orders.saveOrder(order("homer", 2));
-        orders.saveOrder(order("marge", 5));
+        orders.saveOrder(order("homer", 1)).toCompletableFuture().join();
+        orders.saveOrder(order("homer", 2)).toCompletableFuture().join();
+        orders.saveOrder(order("marge", 5)).toCompletableFuture().join();
 
-        assertThat(orders.findOrdersByCustomer("homer").size(), is(2));
-        assertThat(orders.findOrdersByCustomer("marge").size(), is(1));
+        assertThat(orders.findOrdersByCustomer("homer").toCompletableFuture().join().size(), is(2));
+        assertThat(orders.findOrdersByCustomer("marge").toCompletableFuture().join().size(), is(1));
     }
 
     @Test
     void testOrderCreation() {
         Order order = order("homer", 1);
-        orders.saveOrder(order);
+        orders.saveOrder(order).toCompletableFuture().join();
 
-        assertThat(orders.get(order.getOrderId()), is(order));
+        assertThat(orders.get(order.getOrderId()).toCompletableFuture().join(), is(order));
     }
 
 }

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -47,7 +47,7 @@ public class OrderResourceIT {
 
         orders = SERVER.cdiContainer().select(OrderRepository.class).get();
 
-        ((DefaultOrderRepository) orders).clear().toCompletableFuture().join();
+        ((ClearOrderRepository) orders).clear().toCompletableFuture().join();
     }
 
     @Test

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -47,11 +47,7 @@ public class OrderResourceIT {
 
         orders = SERVER.cdiContainer().select(OrderRepository.class).get();
 
-        // oh, boy... not pretty, but probably the best we can do
-        // without adding clear() to public interface
-        WeldClientProxy proxy = (WeldClientProxy) orders;
-        Object o = proxy.getMetadata().getContextualInstance();
-        o.getClass().getMethod("clear").invoke(o);
+        ((DefaultOrderRepository) orders).clear().toCompletableFuture().join();
     }
 
     @Test
@@ -65,7 +61,7 @@ public class OrderResourceIT {
     @Test
     void testGetOrder() {
         Order order = order("homer", 1);
-        orders.saveOrder(order);
+        orders.saveOrder(order).toCompletableFuture().join();
         Order saved = get("/orders/{orderId}", order.getOrderId()).as(Order.class, ObjectMapperType.JSONB);
 
         assertThat(saved, is(order));
@@ -73,9 +69,9 @@ public class OrderResourceIT {
 
     @Test
     void testFindOrdersByCustomerId() {
-        orders.saveOrder(order("homer", 1));
-        orders.saveOrder(order("homer", 2));
-        orders.saveOrder(order("marge", 5));
+        orders.saveOrder(order("homer", 1)).toCompletableFuture().join();
+        orders.saveOrder(order("homer", 2)).toCompletableFuture().join();
+        orders.saveOrder(order("marge", 5)).toCompletableFuture().join();
 
         given().
                 queryParam("custId", "homer").

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -36,7 +36,7 @@ public class OrderResourceIT {
      * This will start the application on ephemeral port to avoid port conflicts.
      * We can discover the actual port by calling {@link io.helidon.microprofile.server.Server#port()} method afterwards.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
+    public static final Server SERVER = Server.builder().port(0).build().start();
     private OrderRepository orders;
 
     @BeforeEach

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/mocks/MockInvocationBuilder.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/mocks/MockInvocationBuilder.java
@@ -2,8 +2,10 @@ package io.helidon.examples.sockshop.orders.mocks;
 
 import java.net.URI;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.client.AsyncInvoker;
+import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.CompletionStageRxInvoker;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -104,7 +106,7 @@ public class MockInvocationBuilder implements Invocation.Builder {
 
     @Override
     public AsyncInvoker async() {
-        return null;
+        return new RInvoker();
     }
 
     @Override
@@ -164,7 +166,7 @@ public class MockInvocationBuilder implements Invocation.Builder {
 
     @Override
     public CompletionStageRxInvoker rx() {
-        return null;
+        return new RInvoker();
     }
 
     @Override
@@ -280,5 +282,186 @@ public class MockInvocationBuilder implements Invocation.Builder {
     @Override
     public <T> T method(String s, Entity<?> entity, GenericType<T> genericType) {
         return null;
+    }
+
+
+    protected class RInvoker implements CompletionStageRxInvoker, AsyncInvoker {
+        @Override
+        public CompletableFuture<Response> get() {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.get());
+        }
+
+        @Override
+        public <T> CompletableFuture<T> get(Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.get(responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> get(GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.get(responseType));
+        }
+
+        public <T> CompletableFuture<T> get(InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> put(Entity<?> entity) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.put(entity));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> put(Entity<?> entity, Class<T> clazz) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.put(entity, clazz));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> put(Entity<?> entity, GenericType<T> type) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.put(entity, type));
+        }
+
+        public <T> CompletableFuture<T> put(Entity<?> entity, InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> post(Entity<?> entity) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.post(entity));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> post(Entity<?> entity, Class<T> clazz) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.post(entity, clazz));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> post(Entity<?> entity, GenericType<T> type) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.post(entity, type));
+        }
+
+        public <T> CompletableFuture<T> post(Entity<?> entity, InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> delete() {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.delete());
+        }
+
+        @Override
+        public <T> CompletableFuture<T> delete(Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.delete(responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> delete(GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.delete(responseType));
+        }
+
+        public <T> CompletableFuture<T> delete(InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> head() {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.head());
+        }
+
+        public CompletableFuture<Response> head(InvocationCallback<Response> callback) {
+            return head().thenApply(r -> { callback.completed(r); return r; })
+                         .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> options() {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.options());
+        }
+
+        @Override
+        public <T> CompletableFuture<T> options(Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.options(responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> options(GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.options(responseType));
+        }
+
+        public <T> CompletableFuture<T> options(InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> trace() {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.trace());
+        }
+
+        @Override
+        public <T> CompletableFuture<T> trace(Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.trace(responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> trace(GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.trace(responseType));
+        }
+
+        public <T> CompletableFuture<T> trace(InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        @Override
+        public CompletableFuture<Response> method(String name) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> method(String name, Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name, responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> method(String name, GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name, responseType));
+        }
+
+        @Override
+        public CompletableFuture<Response> method(String name, Entity<?> entity) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name, entity));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> method(String name, Entity<?> entity, Class<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name, entity, responseType));
+        }
+
+        @Override
+        public <T> CompletableFuture<T> method(String name, Entity<?> entity, GenericType<T> responseType) {
+            return CompletableFuture.completedFuture(MockInvocationBuilder.this.method(name, entity, responseType));
+        }
+
+        public <T> CompletableFuture<T> method(String name, InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
+
+        public <T> CompletableFuture<T> method(String name, Entity<?> entity, InvocationCallback<T> callback) {
+            return CompletableFuture.<T>failedFuture(new Exception("Mock Client does not implement these"))
+                                    .thenApply(r -> { callback.completed(r); return r; })
+                                    .exceptionally(th -> { callback.failed(th); return null; });
+        }
     }
 }

--- a/orders-mongo/pom.xml
+++ b/orders-mongo/pom.xml
@@ -62,7 +62,7 @@
         <!-- Mongo dependencies -->
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
+            <artifactId>mongodb-driver-async</artifactId>
             <version>${version.lib.mongo}</version>
         </dependency>
 
@@ -104,6 +104,33 @@
 
     <build>
         <plugins>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-compiler-plugin</artifactId>
+               <version>3.8.1</version>
+               <configuration>
+                        <source>11</source>
+                        <target>11</target>
+                        <release>11</release>
+                        <!--
+                        https://issues.apache.org/jira/browse/MCOMPILER-346
+
+                        Sometimes you can get NullPointerException in the compiler.
+                        Then upgrading to 3.8.1 you get AssertionError.
+                        Then forcing javac compiler use you may get what the actual
+                        error is.
+
+                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        -->
+                        <compilerArgs>
+                            <arg>-Xlint:unchecked</arg>
+                            <!--
+                            https://issues.apache.org/jira/browse/MCOMPILER-368
+                             -->
+                            <arg>-Xpkginfo:always</arg>
+                        </compilerArgs>
+               </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>

--- a/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoProducers.java
+++ b/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoProducers.java
@@ -10,10 +10,10 @@ import io.helidon.examples.sockshop.orders.Order;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
+import com.mongodb.async.client.MongoClient;
+import com.mongodb.async.client.MongoClients;
+import com.mongodb.async.client.MongoCollection;
+import com.mongodb.async.client.MongoDatabase;
 import lombok.extern.java.Log;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.Conventions;

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/ClearMongoOrderRepository.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/ClearMongoOrderRepository.java
@@ -1,0 +1,36 @@
+package io.helidon.examples.sockshop.orders.mongo;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
+
+import io.helidon.examples.sockshop.orders.ClearOrderRepository;
+import io.helidon.examples.sockshop.orders.Order;
+
+import com.mongodb.async.client.MongoCollection;
+import com.mongodb.async.SingleResultCallback;
+import org.bson.BsonDocument;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class ClearMongoOrderRepository extends MongoOrderRepository implements ClearOrderRepository {
+    @Inject
+    public ClearMongoOrderRepository(MongoCollection<Order> orders) {
+        super(orders);
+    }
+
+    @Override
+    public CompletionStage clear() {
+        return clearRepository(this);
+    }
+
+    public static CompletionStage clearRepository(MongoOrderRepository mor) {
+        CompletableFuture cf = new CompletableFuture();
+        mor.orders.deleteMany(new BsonDocument(), complete(cf));
+        return cf;
+    }
+}

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
@@ -20,6 +20,6 @@ class MongoOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((MongoOrderRepository) orders).clear();
+        ((MongoOrderRepository) orders).clear().toCompletableFuture().join();
     }
 }

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
@@ -20,6 +20,6 @@ class MongoOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((MongoOrderRepository) orders).clear().toCompletableFuture().join();
+        ClearMongoOrderRepository.clearRepository((MongoOrderRepository) orders).toCompletableFuture().join();
     }
 }

--- a/orders-mongo/src/test/resources/META-INF/beans.xml
+++ b/orders-mongo/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/orders-mysql/pom.xml
+++ b/orders-mysql/pom.xml
@@ -66,6 +66,10 @@
           <version>${version.lib.mysql}</version>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-configurable</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.integrations.cdi</groupId>
             <artifactId>helidon-integrations-cdi-datasource-hikaricp</artifactId>
             <scope>runtime</scope>

--- a/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
+++ b/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
@@ -2,12 +2,21 @@ package io.helidon.examples.sockshop.orders.jpa;
 
 import java.util.Collection;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+
+import java.util.function.Supplier;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Specializes;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
+
+import io.helidon.common.configurable.ThreadPoolSupplier;
 
 import io.helidon.examples.sockshop.orders.Order;
 import io.helidon.examples.sockshop.orders.DefaultOrderRepository;
@@ -22,36 +31,69 @@ import org.eclipse.microprofile.opentracing.Traced;
 @Specializes
 @Traced
 public class JpaOrderRepository extends DefaultOrderRepository {
+    @ApplicationScoped
+    @Traced
+    protected static class SyncOrderRepository {
+       @Inject
+       public SyncOrderRepository() {}
 
-    @PersistenceContext
-    private EntityManager em;
+       @PersistenceContext
+       protected EntityManager em;
+
+       @Transactional
+       public Collection<? extends Order> findOrdersByCustomerSync(String customerId) {
+          String jql = "select o from Order as o where o.customer.id = :customerId order by o.date";
+          TypedQuery<Order> query = em.createQuery(jql, Order.class);
+          query.setParameter("customerId", customerId);
+
+          return query.getResultList();
+       }
+
+       @Transactional
+       public Order getSync(String orderId) {
+          return em.find(Order.class, orderId);
+       }
+
+       @Transactional
+       public void saveOrderSync(Order order) {
+          em.persist(order);
+       }
+
+       @Transactional
+       public void clearSync() {
+          em.createQuery("delete from Item").executeUpdate();
+          em.createQuery("delete from Order").executeUpdate();
+       }
+    }
+
+    @Inject
+    protected SyncOrderRepository repo;
+
+    protected static final Supplier<ExecutorService> ses = ThreadPoolSupplier.builder()
+                                          .threadNamePrefix("jpa-em-")
+                                          .build();
+
+    // TODO: make it configurable
+    protected static final ExecutorService es = ses.get();
 
     @Override
-    @Transactional
-    public Collection<? extends Order> findOrdersByCustomer(String customerId) {
-        String jql = "select o from Order as o where o.customer.id = :customerId order by o.date";
-        TypedQuery<Order> query = em.createQuery(jql, Order.class);
-        query.setParameter("customerId", customerId);
-
-        return query.getResultList();
+    public CompletionStage<Collection<? extends Order>> findOrdersByCustomer(String customerId) {
+        return CompletableFuture.supplyAsync(() -> repo.findOrdersByCustomerSync(customerId), es);
     }
 
     @Override
-    @Transactional
-    public Order get(String orderId) {
-        return em.find(Order.class, orderId);
+    public CompletionStage<Order> get(String orderId) {
+        return CompletableFuture.supplyAsync(() -> repo.getSync(orderId), es);
     }
 
     @Override
-    @Transactional
-    public void saveOrder(Order order) {
-        em.persist(order);
+    public CompletionStage saveOrder(Order order) {
+        return CompletableFuture.supplyAsync(() -> {repo.saveOrderSync(order); return true;}, es);
     }
 
     @Override
-    @Transactional
-    public void clear() {
-        em.createQuery("delete from Item").executeUpdate();
-        em.createQuery("delete from Order").executeUpdate();
+    public CompletionStage clear() {
+        return CompletableFuture.supplyAsync(() -> {repo.clearSync(); return true;}, es);
     }
+
 }

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/ClearJpaOrderRepository.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/ClearJpaOrderRepository.java
@@ -1,0 +1,35 @@
+package io.helidon.examples.sockshop.orders.jpa;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+import javax.transaction.Transactional;
+
+import io.helidon.examples.sockshop.orders.ClearOrderRepository;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class ClearJpaOrderRepository extends JpaOrderRepository implements ClearOrderRepository {
+    @Alternative
+    @Priority(Interceptor.Priority.APPLICATION+100)
+    protected static class ClearSyncOrderRepository extends SyncOrderRepository {
+       @Transactional
+       public boolean clearSync() {
+          em.createQuery("delete from Item").executeUpdate();
+          em.createQuery("delete from Order").executeUpdate();
+          return true;
+       }
+    }
+
+    @Override
+    public CompletionStage clear() {
+        return CompletableFuture.supplyAsync(() -> ((ClearSyncOrderRepository)repo).clearSync(), es);
+    }
+
+    public static CompletionStage clearRepository(ClearJpaOrderRepository cor) {
+        return cor.clear();
+    }
+}

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -24,6 +24,6 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((JpaOrderRepository) orders).clear().toCompletableFuture().join();
+        ClearJpaOrderRepository.clearRepository((ClearJpaOrderRepository) orders).toCompletableFuture().join();
     }
 }

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -15,12 +15,7 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
      * Starting server on ephemeral port in order to be able to get the
      * fully configured repository from the CDI container.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
-
-    @AfterAll
-    static void stopServer() {
-        SERVER.stop();
-    }
+    private static final Server SERVER = JpaOrderResourceIT.SERVER;
 
     @Override
     protected OrderRepository getOrderRepository() {

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -24,6 +24,6 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((JpaOrderRepository) orders).clear();
+        ((JpaOrderRepository) orders).clear().toCompletableFuture().join();
     }
 }

--- a/orders-mysql/src/test/resources/META-INF/beans.xml
+++ b/orders-mysql/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/ClearRedisOrderRepository.java
+++ b/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/ClearRedisOrderRepository.java
@@ -1,0 +1,33 @@
+package io.helidon.examples.sockshop.orders.redis;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
+
+import io.helidon.examples.sockshop.orders.ClearOrderRepository;
+import io.helidon.examples.sockshop.orders.Order;
+
+import org.redisson.api.RMap;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class ClearRedisOrderRepository extends RedisOrderRepository implements ClearOrderRepository {
+    @Inject
+    public ClearRedisOrderRepository(RMap<String, Order> carts) {
+        super(carts);
+    }
+
+    @Override
+    public CompletionStage clear() {
+        return clearRepository(this);
+    }
+
+    public static CompletionStage clearRepository(RedisOrderRepository ror) {
+        return ror.carts.readAllKeySetAsync()
+                        .thenApply(ks -> ror.carts.fastRemoveAsync(ks.toArray(new String[ks.size()])));
+    }
+}

--- a/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepositoryIT.java
+++ b/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepositoryIT.java
@@ -19,6 +19,6 @@ class RedisOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected void clearRepository(OrderRepository orders) {
-        ((RedisOrderRepository) orders).clear();
+        ClearRedisOrderRepository.clearRepository((RedisOrderRepository) orders).toCompletableFuture().join();
     }
 }

--- a/orders-redis/src/test/resources/META-INF/beans.xml
+++ b/orders-redis/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
End goal is to showcase the use of MP features to declaratively use (asynchronous) REST Client. The actual declarative use of MP REST Client will be done in the future, as it will benefit from request format changes (eg don't use full URL, only the data to pass to the services).

The current Jersey shipped with Helidon 1.4 has issues with RX client, but upgrading to Jersey 2.30+ allows configuring JAX-RS Jersey Connector Provider. In particular, `NettyConnectorProvider`, which I would recommend for use with Helidon, since it is also Netty-based.

Additionally, intrusive testware changes to eliminate the declaration of `clear()` test method.