### PR TITLE
Fix the testware issue: cannot use two Servers

### DIFF
--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -36,7 +36,7 @@ public class OrderResourceIT {
      * This will start the application on ephemeral port to avoid port conflicts.
      * We can discover the actual port by calling {@link io.helidon.microprofile.server.Server#port()} method afterwards.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
+    public static final Server SERVER = Server.builder().port(0).build().start();
     private OrderRepository orders;
 
     @BeforeEach

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -15,12 +15,7 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
      * Starting server on ephemeral port in order to be able to get the
      * fully configured repository from the CDI container.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
-
-    @AfterAll
-    static void stopServer() {
-        SERVER.stop();
-    }
+    private static final Server SERVER = JpaOrderResourceIT.SERVER;
 
     @Override
     protected OrderRepository getOrderRepository() {


### PR DESCRIPTION
Problem: Helidon does not support starting Server more than once per Java process.

Solution: Make tests share a singleton instance.

Issues: #2