### PR TITLE
Remove test-only methods from OrderRepository - fixes #3

### DIFF
--- a/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
+++ b/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
@@ -5,7 +5,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
 
 import org.eclipse.microprofile.opentracing.Traced;
 
@@ -18,9 +21,11 @@ import org.eclipse.microprofile.opentracing.Traced;
  * API testing and quick demos.
  */
 @ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+1)
 @Traced
 public class DefaultOrderRepository implements OrderRepository {
-    private Map<String, Order> orders;
+    protected Map<String, Order> orders;
 
     /**
      * Construct {@code DefaultOrderRepository} with empty storage map.
@@ -53,14 +58,5 @@ public class DefaultOrderRepository implements OrderRepository {
     @Override
     public void saveOrder(Order order) {
         orders.put(order.getOrderId(), order);
-    }
-
-    // ---- helpers ---------------------------------------------------------
-
-    /**
-     * Helper to clear this repository for testing.
-     */
-    public void clear() {
-        orders.clear();
     }
 }

--- a/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
+++ b/orders-core/src/main/java/io/helidon/examples/sockshop/orders/DefaultOrderRepository.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 import javax.interceptor.Interceptor;
 
 import org.eclipse.microprofile.opentracing.Traced;
@@ -21,8 +20,7 @@ import org.eclipse.microprofile.opentracing.Traced;
  * API testing and quick demos.
  */
 @ApplicationScoped
-@Alternative
-@Priority(Interceptor.Priority.APPLICATION+1)
+@Priority(Interceptor.Priority.APPLICATION-10)
 @Traced
 public class DefaultOrderRepository implements OrderRepository {
     protected Map<String, Order> orders;

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/DefaultOrderRepositoryTest.java
@@ -6,11 +6,6 @@ package io.helidon.examples.sockshop.orders;
 public class DefaultOrderRepositoryTest extends OrderRepositoryTest {
     @Override
     protected OrderRepository getOrderRepository() {
-        return new DefaultOrderRepository();
-    }
-
-    @Override
-    protected void clearRepository(OrderRepository orders) {
-        ((DefaultOrderRepository) orders).clear();
+        return new TestDefaultOrderRepository();
     }
 }

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderRepositoryTest.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderRepositoryTest.java
@@ -15,11 +15,10 @@ public abstract class OrderRepositoryTest {
     private OrderRepository orders = getOrderRepository();
 
     protected abstract OrderRepository getOrderRepository();
-    protected abstract void clearRepository(OrderRepository orders);
 
     @BeforeEach
     void setup() {
-        clearRepository(orders);
+        ((TestOrderRepository)orders).clear();
     }
 
     @Test

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -47,11 +47,7 @@ public class OrderResourceIT {
 
         orders = SERVER.cdiContainer().select(OrderRepository.class).get();
 
-        // oh, boy... not pretty, but probably the best we can do
-        // without adding clear() to public interface
-        WeldClientProxy proxy = (WeldClientProxy) orders;
-        Object o = proxy.getMetadata().getContextualInstance();
-        o.getClass().getMethod("clear").invoke(o);
+        ((TestOrderRepository) orders).clear();
     }
 
     @Test

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/OrderResourceIT.java
@@ -36,7 +36,7 @@ public class OrderResourceIT {
      * This will start the application on ephemeral port to avoid port conflicts.
      * We can discover the actual port by calling {@link io.helidon.microprofile.server.Server#port()} method afterwards.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
+    public static final Server SERVER = Server.builder().port(0).build().start();
     private OrderRepository orders;
 
     @BeforeEach

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestDefaultOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestDefaultOrderRepository.java
@@ -5,7 +5,7 @@ import javax.enterprise.inject.Alternative;
 import javax.interceptor.Interceptor;
 
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION-5)
 public class TestDefaultOrderRepository extends DefaultOrderRepository implements TestOrderRepository {
     public TestDefaultOrderRepository() {}
 

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestDefaultOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestDefaultOrderRepository.java
@@ -1,0 +1,16 @@
+package io.helidon.examples.sockshop.orders;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
+public class TestDefaultOrderRepository extends DefaultOrderRepository implements TestOrderRepository {
+    public TestDefaultOrderRepository() {}
+
+    @Override
+    public void clear() {
+        orders.clear();
+    }
+}

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestOrderRepository.java
@@ -1,0 +1,7 @@
+package io.helidon.examples.sockshop.orders;
+
+// Tests need to interact with the entity backing OrderRepository
+// to reset to initial state before every test
+public interface TestOrderRepository {
+    public void clear();
+}

--- a/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestOrderRepository.java
+++ b/orders-core/src/test/java/io/helidon/examples/sockshop/orders/TestOrderRepository.java
@@ -1,7 +1,24 @@
 package io.helidon.examples.sockshop.orders;
 
-// Tests need to interact with the entity backing OrderRepository
-// to reset to initial state before every test
+/**
+ * Tests need to interact with the entity backing OrderRepository
+ * to reset to initial state before every test. In order to reduce
+ * programming errors, the methods needed for the tests should reside
+ * in test project. Since various repositories have
+ * implementation-specific ways of clearing the repository, they need
+ * to extend actual implementations by implementing TestOrderRepository
+ * interface. The test rig then can cast the repository it obtains
+ * through CDI to a TestOrderRepository, and can clear the repository
+ * between the tests.
+ *
+ * <p>Note that for the CDI to work it is necessary to mark the test
+ * repositories with @Alternative and @Priority exceeding that of the
+ * implementation.
+ *
+ * <p>Note that for the tests to test the actual implementation it is
+ * necessary that the test implementations only extend the class, but
+ * do not override any methods.
+ */
 public interface TestOrderRepository {
     public void clear();
 }

--- a/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepository.java
+++ b/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepository.java
@@ -26,7 +26,7 @@ import static com.mongodb.client.model.Filters.eq;
  */
 @ApplicationScoped
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION)
 @Traced
 public class MongoOrderRepository implements OrderRepository {
     protected MongoCollection<Order> orders;

--- a/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepository.java
+++ b/orders-mongo/src/main/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepository.java
@@ -5,12 +5,14 @@ import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Specializes;
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 
-import io.helidon.examples.sockshop.orders.DefaultOrderRepository;
 import io.helidon.examples.sockshop.orders.Order;
+import io.helidon.examples.sockshop.orders.OrderRepository;
 
 import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
@@ -23,11 +25,11 @@ import static com.mongodb.client.model.Filters.eq;
  * that that uses MongoDB as a backend data store.
  */
 @ApplicationScoped
-@Specializes
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
 @Traced
-public class MongoOrderRepository extends DefaultOrderRepository {
-
-    private MongoCollection<Order> orders;
+public class MongoOrderRepository implements OrderRepository {
+    protected MongoCollection<Order> orders;
 
     @Inject
     MongoOrderRepository(MongoCollection<Order> orders) {
@@ -52,12 +54,5 @@ public class MongoOrderRepository extends DefaultOrderRepository {
     @Override
     public void saveOrder(Order order) {
         orders.insertOne(order);
-    }
-
-    // ---- helpers ---------------------------------------------------------
-
-    @Override
-    public void clear() {
-        orders.deleteMany(new BsonDocument());
     }
 }

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/MongoOrderRepositoryIT.java
@@ -15,11 +15,6 @@ class MongoOrderRepositoryIT extends OrderRepositoryTest {
         String host = System.getProperty("db.host","localhost");
         int    port = Integer.parseInt(System.getProperty("db.port","27017"));
 
-        return new MongoOrderRepository(orders(db(client(host, port))));
-    }
-
-    @Override
-    protected void clearRepository(OrderRepository orders) {
-        ((MongoOrderRepository) orders).clear();
+        return new TestMongoOrderRepository(orders(db(client(host, port))));
     }
 }

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/TestMongoOrderRepository.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/TestMongoOrderRepository.java
@@ -12,7 +12,7 @@ import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
 
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+100)
+@Priority(Interceptor.Priority.APPLICATION+5)
 public class TestMongoOrderRepository extends MongoOrderRepository implements TestOrderRepository {
     @Inject
     public TestMongoOrderRepository(MongoCollection<Order> orders) {

--- a/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/TestMongoOrderRepository.java
+++ b/orders-mongo/src/test/java/io/helidon/examples/sockshop/orders/mongo/TestMongoOrderRepository.java
@@ -1,0 +1,26 @@
+package io.helidon.examples.sockshop.orders.mongo;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
+
+import io.helidon.examples.sockshop.orders.TestOrderRepository;
+import io.helidon.examples.sockshop.orders.Order;
+
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonDocument;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class TestMongoOrderRepository extends MongoOrderRepository implements TestOrderRepository {
+    @Inject
+    public TestMongoOrderRepository(MongoCollection<Order> orders) {
+        super(orders);
+    }
+
+    @Override
+    public void clear() {
+        orders.deleteMany(new BsonDocument());
+    }
+}

--- a/orders-mongo/src/test/resources/META-INF/beans.xml
+++ b/orders-mongo/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
+++ b/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
@@ -2,15 +2,18 @@ package io.helidon.examples.sockshop.orders.jpa;
 
 import java.util.Collection;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Specializes;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 
 import io.helidon.examples.sockshop.orders.Order;
-import io.helidon.examples.sockshop.orders.DefaultOrderRepository;
+import io.helidon.examples.sockshop.orders.OrderRepository;
 
 import org.eclipse.microprofile.opentracing.Traced;
 
@@ -19,12 +22,13 @@ import org.eclipse.microprofile.opentracing.Traced;
  * that that uses relational database (via JPA) as a backend data store.
  */
 @ApplicationScoped
-@Specializes
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
 @Traced
-public class JpaOrderRepository extends DefaultOrderRepository {
+public class JpaOrderRepository implements OrderRepository {
 
     @PersistenceContext
-    private EntityManager em;
+    protected EntityManager em;
 
     @Override
     @Transactional
@@ -46,12 +50,5 @@ public class JpaOrderRepository extends DefaultOrderRepository {
     @Transactional
     public void saveOrder(Order order) {
         em.persist(order);
-    }
-
-    @Override
-    @Transactional
-    public void clear() {
-        em.createQuery("delete from Item").executeUpdate();
-        em.createQuery("delete from Order").executeUpdate();
     }
 }

--- a/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
+++ b/orders-mysql/src/main/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepository.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.opentracing.Traced;
  */
 @ApplicationScoped
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION)
 @Traced
 public class JpaOrderRepository implements OrderRepository {
 

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -15,12 +15,7 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
      * Starting server on ephemeral port in order to be able to get the
      * fully configured repository from the CDI container.
      */
-    private static final Server SERVER = Server.builder().port(0).build().start();
-
-    @AfterAll
-    static void stopServer() {
-        SERVER.stop();
-    }
+    private static final Server SERVER = JpaOrderResourceIT.SERVER;
 
     @Override
     protected OrderRepository getOrderRepository() {

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/JpaOrderRepositoryIT.java
@@ -19,11 +19,7 @@ public class JpaOrderRepositoryIT extends OrderRepositoryTest {
 
     @Override
     protected OrderRepository getOrderRepository() {
+        // using CDI, because only this way we can interact with @Transactional annotations
         return SERVER.cdiContainer().select(OrderRepository.class).get();
-    }
-
-    @Override
-    protected void clearRepository(OrderRepository orders) {
-        ((JpaOrderRepository) orders).clear();
     }
 }

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/TestJpaOrderRepository.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/TestJpaOrderRepository.java
@@ -1,0 +1,18 @@
+package io.helidon.examples.sockshop.orders.jpa;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.interceptor.Interceptor;
+import javax.transaction.Transactional;
+
+import io.helidon.examples.sockshop.orders.TestOrderRepository;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class TestJpaOrderRepository extends JpaOrderRepository implements TestOrderRepository {
+    @Transactional
+    public void clear() {
+        em.createQuery("delete from Item").executeUpdate();
+        em.createQuery("delete from Order").executeUpdate();
+    }
+}

--- a/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/TestJpaOrderRepository.java
+++ b/orders-mysql/src/test/java/io/helidon/examples/sockshop/orders/jpa/TestJpaOrderRepository.java
@@ -8,7 +8,7 @@ import javax.transaction.Transactional;
 import io.helidon.examples.sockshop.orders.TestOrderRepository;
 
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+100)
+@Priority(Interceptor.Priority.APPLICATION+5)
 public class TestJpaOrderRepository extends JpaOrderRepository implements TestOrderRepository {
     @Transactional
     public void clear() {

--- a/orders-mysql/src/test/resources/META-INF/beans.xml
+++ b/orders-mysql/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>

--- a/orders-redis/src/main/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepository.java
+++ b/orders-redis/src/main/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepository.java
@@ -10,7 +10,7 @@ import javax.inject.Inject;
 import javax.interceptor.Interceptor;
 
 import io.helidon.examples.sockshop.orders.Order;
-import io.helidon.examples.sockshop.orders.OrderRepository;
+import io.helidon.examples.sockshop.orders.DefaultOrderRepository;
 
 import org.eclipse.microprofile.opentracing.Traced;
 import org.redisson.api.RMap;
@@ -21,43 +21,11 @@ import org.redisson.api.RMap;
  */
 @ApplicationScoped
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION)
 @Traced
-public class RedisOrderRepository implements OrderRepository {
-    protected RMap<String, Order> carts;
-
+public class RedisOrderRepository extends DefaultOrderRepository {
     @Inject
     public RedisOrderRepository(RMap<String, Order> carts) {
-        this.carts = carts;
-    }
-
-    @Override
-    public Collection<? extends Order> findOrdersByCustomer(String customerId) {
-        return findOrdersByCustomerAsync(customerId).toCompletableFuture().join();
-    }
-
-    @Override
-    public Order get(String orderId) {
-        return getAsync(orderId).toCompletableFuture().join();
-    }
-
-    @Override
-    public void saveOrder(Order order) {
-        saveOrderAsync(order).toCompletableFuture().join();
-    }
-
-    public CompletionStage<Collection<? extends Order>> findOrdersByCustomerAsync(String customerId) {
-        return carts.readAllValuesAsync()
-                    .thenApply(vs -> vs.stream()
-                                     .filter(order -> order.getCustomer().getId().equals(customerId))
-                                     .collect(Collectors.toList()));
-    }
-
-    public CompletionStage<Order> getAsync(String orderId) {
-        return carts.getAsync(orderId);
-    }
-
-    public CompletionStage saveOrderAsync(Order order) {
-        return carts.putAsync(order.getOrderId(), order);
+        super(carts);
     }
 }

--- a/orders-redis/src/main/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepository.java
+++ b/orders-redis/src/main/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepository.java
@@ -1,11 +1,16 @@
 package io.helidon.examples.sockshop.orders.redis;
 
+import java.util.Collection;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Specializes;
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import javax.interceptor.Interceptor;
 
-import io.helidon.examples.sockshop.orders.DefaultOrderRepository;
 import io.helidon.examples.sockshop.orders.Order;
+import io.helidon.examples.sockshop.orders.OrderRepository;
 
 import org.eclipse.microprofile.opentracing.Traced;
 import org.redisson.api.RMap;
@@ -15,11 +20,44 @@ import org.redisson.api.RMap;
  * that that uses Redis (via Redisson) as a backend data store.
  */
 @ApplicationScoped
-@Specializes
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+10)
 @Traced
-public class RedisOrderRepository extends DefaultOrderRepository {
+public class RedisOrderRepository implements OrderRepository {
+    protected RMap<String, Order> carts;
+
     @Inject
     public RedisOrderRepository(RMap<String, Order> carts) {
-        super(carts);
+        this.carts = carts;
+    }
+
+    @Override
+    public Collection<? extends Order> findOrdersByCustomer(String customerId) {
+        return findOrdersByCustomerAsync(customerId).toCompletableFuture().join();
+    }
+
+    @Override
+    public Order get(String orderId) {
+        return getAsync(orderId).toCompletableFuture().join();
+    }
+
+    @Override
+    public void saveOrder(Order order) {
+        saveOrderAsync(order).toCompletableFuture().join();
+    }
+
+    public CompletionStage<Collection<? extends Order>> findOrdersByCustomerAsync(String customerId) {
+        return carts.readAllValuesAsync()
+                    .thenApply(vs -> vs.stream()
+                                     .filter(order -> order.getCustomer().getId().equals(customerId))
+                                     .collect(Collectors.toList()));
+    }
+
+    public CompletionStage<Order> getAsync(String orderId) {
+        return carts.getAsync(orderId);
+    }
+
+    public CompletionStage saveOrderAsync(Order order) {
+        return carts.putAsync(order.getOrderId(), order);
     }
 }

--- a/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepositoryIT.java
+++ b/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/RedisOrderRepositoryIT.java
@@ -14,11 +14,6 @@ class RedisOrderRepositoryIT extends OrderRepositoryTest {
         String host = System.getProperty("db.host","localhost");
         int    port = Integer.parseInt(System.getProperty("db.port","6379"));
 
-        return new RedisOrderRepository(orders(client(host, port)));
-    }
-
-    @Override
-    protected void clearRepository(OrderRepository orders) {
-        ((RedisOrderRepository) orders).clear();
+        return new TestRedisOrderRepository(orders(client(host, port)));
     }
 }

--- a/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/TestRedisOrderRepository.java
+++ b/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/TestRedisOrderRepository.java
@@ -1,0 +1,28 @@
+package io.helidon.examples.sockshop.orders.redis;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.interceptor.Interceptor;
+
+import io.helidon.examples.sockshop.orders.TestOrderRepository;
+import io.helidon.examples.sockshop.orders.Order;
+
+import org.redisson.api.RMap;
+
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION+100)
+public class TestRedisOrderRepository extends RedisOrderRepository implements TestOrderRepository {
+    @Inject
+    public TestRedisOrderRepository(RMap<String, Order> carts) {
+        super(carts);
+    }
+
+    @Override
+    public void clear() {
+        carts.readAllKeySetAsync()
+             .thenCompose(ks -> carts.fastRemoveAsync(ks.toArray(new String[ks.size()])))
+             .toCompletableFuture()
+             .join();
+    }
+}

--- a/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/TestRedisOrderRepository.java
+++ b/orders-redis/src/test/java/io/helidon/examples/sockshop/orders/redis/TestRedisOrderRepository.java
@@ -11,7 +11,7 @@ import io.helidon.examples.sockshop.orders.Order;
 import org.redisson.api.RMap;
 
 @Alternative
-@Priority(Interceptor.Priority.APPLICATION+100)
+@Priority(Interceptor.Priority.APPLICATION+5)
 public class TestRedisOrderRepository extends RedisOrderRepository implements TestOrderRepository {
     @Inject
     public TestRedisOrderRepository(RMap<String, Order> carts) {
@@ -20,9 +20,6 @@ public class TestRedisOrderRepository extends RedisOrderRepository implements Te
 
     @Override
     public void clear() {
-        carts.readAllKeySetAsync()
-             .thenCompose(ks -> carts.fastRemoveAsync(ks.toArray(new String[ks.size()])))
-             .toCompletableFuture()
-             .join();
+        orders.clear();
     }
 }

--- a/orders-redis/src/test/resources/META-INF/beans.xml
+++ b/orders-redis/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        version="2.0"
+        bean-discovery-mode="annotated">
+</beans>


### PR DESCRIPTION
Problem: clear() method is used for testing only. Should not exist
       for production use.

Solution: Move it to test classes. This requires reorganizing how
       inheritance works, and how CDI picks up the right implementation
       in tests. @Specializes cannot be used - test implementations
       are seen as ambiguous. Using @Alternative with @Priority appears
       to be the standard way of achieving this. This requires beans.xml
       for all tests.

Issues: fixes #3